### PR TITLE
Fix creating archives at root level

### DIFF
--- a/source/setup/js/ConnectArchiveDialog.jsx
+++ b/source/setup/js/ConnectArchiveDialog.jsx
@@ -56,10 +56,15 @@ class ConnectArchiveDialog extends Component {
     }
 
     onOptionChange(e) {
-        let newOption = (typeof e === "string") ? e : e.target.value;
+        const newOption = (typeof e === "string") ? e : e.target.value;
+        const additionalChanges = {};
+        if (newOption === "new") {
+            additionalChanges.createNew = true;
+        }
         this.setState({
             allowSelectArchive: (newOption === "existing"),
-            currentOption: newOption
+            currentOption: newOption,
+            ...additionalChanges
         });
     }
 


### PR DESCRIPTION
This addresses #69 where archives were not able to be created at the root level. This was due to state not being updated.