### PR TITLE
added autofocus property to entry search bar input tag

### DIFF
--- a/source/popup/components/EntriesPage.js
+++ b/source/popup/components/EntriesPage.js
@@ -24,6 +24,7 @@ export default class EntriesPage extends PureComponent {
                         className={Classes.FILL}
                         type="search"
                         leftIcon="search"
+                        autoFocus={true}
                         onChange={::this.handleSearchTermChange}
                     />
                 </SearchInputWrapper>


### PR DESCRIPTION
Resolves #216. The property will now cause the search bar to autofocus when the popup is opened