### PR TITLE
Remove warning from Redux package

### DIFF
--- a/source/dialog/redux/history.js
+++ b/source/dialog/redux/history.js
@@ -1,3 +1,3 @@
-import createHistory from "history/createHashHistory";
+import { createHashHistory } from "history";
 
-export default createHistory();
+export default createHashHistory();

--- a/source/popup/redux/history.js
+++ b/source/popup/redux/history.js
@@ -1,3 +1,3 @@
-import createHistory from "history/createMemoryHistory";
+import { createMemoryHistory } from "history";
 
-export default createHistory();
+export default createMemoryHistory();

--- a/source/setup/redux/history.js
+++ b/source/setup/redux/history.js
@@ -1,3 +1,3 @@
-import createHistory from "history/createHashHistory";
+import { createHashHistory } from "history";
 
-export default createHistory();
+export default createHashHistory();


### PR DESCRIPTION
> Warning: Please use `require("history").createHashHistory` instead of `require("history/createHashHistory")`. Support for the latter will be removed in the next major release.