### PR TITLE
Improvements to add archive page

### DIFF
--- a/source/setup/components/AddArchivePage.js
+++ b/source/setup/components/AddArchivePage.js
@@ -19,6 +19,10 @@ const SplitView = styled.div`
     grid-template-columns: repeat(2, calc(50% - 0.5rem));
     grid-gap: 1rem;
 `;
+const RemoteExplorerCard = styled(Card)`
+    max-height: 640px;
+    overflow: auto;
+`;
 
 class AddArchivePage extends PureComponent {
     static propTypes = {
@@ -166,7 +170,7 @@ class AddArchivePage extends PureComponent {
                         <When condition={hasAuthenticated}>
                             <H4>Choose or Create Vault</H4>
                             <SplitView>
-                                <Card>
+                                <RemoteExplorerCard>
                                     <RemoteExplorer
                                         onCreateRemotePath={path => this.props.onCreateRemotePath(path)}
                                         onSelectRemotePath={path => this.props.onSelectRemotePath(path)}
@@ -174,7 +178,7 @@ class AddArchivePage extends PureComponent {
                                         selectedFilenameNeedsCreation={this.props.selectedFilenameNeedsCreation}
                                         fetchType={fetchType}
                                     />
-                                </Card>
+                                </RemoteExplorerCard>
                                 <Card>{this.renderArchiveNameInput()}</Card>
                             </SplitView>
                         </When>

--- a/source/setup/components/AddArchivePage.js
+++ b/source/setup/components/AddArchivePage.js
@@ -197,7 +197,8 @@ class AddArchivePage extends PureComponent {
             .case("dropbox", ::this.handleChooseDropboxBasedFile)
             .case("googledrive", ::this.handleChooseGoogleDriveBasedFile)
             .case("localfile", ::this.handleChooseLocalBasedFile);
-        const onClickHandler = onClickTypeSwitch(this.props.selectedArchiveType);
+        const handleSubmit = onClickTypeSwitch(this.props.selectedArchiveType);
+
         return (
             <Fragment>
                 <FormGroup full label="Name" labelInfo="(required)" disabled={disabled}>
@@ -206,6 +207,7 @@ class AddArchivePage extends PureComponent {
                         disabled={disabled}
                         placeholder="Enter vault name..."
                         onChange={event => this.handleUpdateForm("archiveName", event)}
+                        onKeyPress={event => (event.key === "Enter" ? handleSubmit(event) : true)}
                         value={this.state.archiveName}
                     />
                 </FormGroup>
@@ -216,10 +218,11 @@ class AddArchivePage extends PureComponent {
                         placeholder="Enter vault password..."
                         type="password"
                         onChange={event => this.handleUpdateForm("masterPassword", event)}
+                        onKeyPress={event => (event.key === "Enter" ? handleSubmit(event) : true)}
                         value={this.state.masterPassword}
                     />
                 </FormGroup>
-                <Button fill disabled={disabled} onClick={onClickHandler}>
+                <Button fill disabled={disabled} onClick={handleSubmit}>
                     Save Vault
                 </Button>
             </Fragment>
@@ -346,6 +349,7 @@ class AddArchivePage extends PureComponent {
                                     disabled={hasAuthenticatedDesktop || !this.props.isConnected}
                                     loading={isAuthenticatingDesktop && !hasAuthenticatedDesktop}
                                     onChange={event => this.setState({ localCode: event.target.value.toUpperCase() })}
+                                    onKeyPress={e => (e.key === "Enter" ? this.handleConnectLocal(e) : true)}
                                     value={this.state.localCode}
                                 />
                             </FormGroup>

--- a/source/setup/components/LoadingModal.js
+++ b/source/setup/components/LoadingModal.js
@@ -16,7 +16,7 @@ const Overlay = styled.div`
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    z-index: 2;
+    z-index: 50;
 `;
 const LoadingText = styled.div`
     font-size: 1.2rem;

--- a/source/setup/components/RemoteFileTree.js
+++ b/source/setup/components/RemoteFileTree.js
@@ -89,8 +89,13 @@ class RemoteFileTree extends Component {
         openDirectories: ["/"]
     };
 
-    handleFileClick({ nodeData }, _, e) {
-        if (!nodeData || typeof nodeData.directories !== "undefined" || !/\.bcup$/i.test(nodeData.name)) {
+    handleNodeClick({ nodeData }, _, e) {
+        // handle directories
+        if (nodeData && typeof nodeData.directories !== "undefined") {
+            this.handleNodeToggle(...arguments);
+            return;
+            // ignore if it isn't a bcup file
+        } else if (!nodeData || !/\.bcup$/i.test(nodeData.name)) {
             e.preventDefault();
             return;
         }
@@ -163,6 +168,15 @@ class RemoteFileTree extends Component {
         this.setState({
             openDirectories: this.state.openDirectories.filter(dir => dir !== nodeData.path)
         });
+    }
+
+    handleNodeToggle({ nodeData }, _, e) {
+        const isExpanded = this.state.openDirectories.includes(nodeData.path);
+        if (isExpanded) {
+            this.handleNodeCollapse(...arguments);
+        } else {
+            this.handleNodeExpand(...arguments);
+        }
     }
 
     getTreeNewItem(parentPath) {
@@ -245,8 +259,8 @@ class RemoteFileTree extends Component {
                         contents={this.getTree(this.props.rootDirectory).childNodes}
                         onNodeExpand={::this.handleNodeExpand}
                         onNodeCollapse={::this.handleNodeCollapse}
-                        onNodeDoubleClick={::this.handleNodeExpand}
-                        onNodeClick={::this.handleFileClick}
+                        onNodeDoubleClick={::this.handleNodeToggle}
+                        onNodeClick={::this.handleNodeClick}
                     />
                 </Otherwise>
             </Choose>

--- a/source/setup/components/RemoteFileTree.js
+++ b/source/setup/components/RemoteFileTree.js
@@ -212,6 +212,7 @@ class RemoteFileTree extends Component {
             hasCaret: isDir,
             icon: isDir ? "folder-close" : "document",
             nodeData: directory,
+            disabled: !isDir && !/\.bcup$/i.test(directory.name),
             childNodes: this.props.directoriesLoading.includes(directory.path)
                 ? [
                       {

--- a/source/setup/containers/AddArchivePage.js
+++ b/source/setup/containers/AddArchivePage.js
@@ -227,7 +227,7 @@ export default connect(
         ) => {
             const name = stripTags(archiveName);
             if (/^[^\s]/.test(name) !== true) {
-                notifyError(`Failed selecting ${type} vault`, `Vault name is invalid: ${name}`);
+                notifyError(`Failed selecting WebDAV vault`, `Vault name is invalid: ${name}`);
                 return;
             }
             const state = getState();

--- a/source/setup/containers/AddArchivePage.js
+++ b/source/setup/containers/AddArchivePage.js
@@ -194,7 +194,7 @@ export default connect(
         onChooseLocallyBasedArchive: (archiveName, masterPassword) => (dispatch, getState) => {
             const name = stripTags(archiveName);
             if (/^[^\s]/.test(name) !== true) {
-                notifyError(`Failed selecting ${type} vault`, `Vault name is invalid: ${name}`);
+                notifyError(`Failed selecting local vault`, `Vault name is invalid: ${name}`);
                 return;
             }
             const state = getState();

--- a/source/setup/library/remote.js
+++ b/source/setup/library/remote.js
@@ -25,7 +25,6 @@ export function connectWebDAV(url, username, password) {
             return;
         }
         log.error(`Failed establishing WebDAV connection: ${url}`);
-        throw new Error(`Connection failed to WebDAV service: ${url}`);
     });
 }
 
@@ -38,7 +37,8 @@ function getDropboxFSClient() {
         const state = getState();
         const authToken = getDropboxAuthToken(state);
         if (!authToken) {
-            throw new Error("Unable to create Dropbox client: No token found");
+            log.error("Unable to create Dropbox client: No token found");
+            return;
         }
         __dropboxClient = createDropboxFSClient(createDropboxClient(authToken));
     }
@@ -62,7 +62,8 @@ function getGoogleDriveClient() {
         const state = getState();
         const accessToken = getGoogleDriveAccessToken(state);
         if (!accessToken) {
-            throw new Error("Unable to create Google Drive client: No token found");
+            log.error("Unable to create Google Drive client: No token found");
+            return;
         }
         __googleDriveClient = createGoogleDriveClient(accessToken);
     }

--- a/source/setup/styles/setup.sass
+++ b/source/setup/styles/setup.sass
@@ -7,3 +7,7 @@ html, body
     display: flex
     justify-content: center
     min-height: 100%
+
+.bp3-tree-node-label
+    overflow: visible
+    text-overflow: initial

--- a/source/setup/styles/setup.sass
+++ b/source/setup/styles/setup.sass
@@ -8,6 +8,9 @@ html, body
     justify-content: center
     min-height: 100%
 
+.bp3-tree-node
+    cursor: pointer
+
 .bp3-tree-node-label
     overflow: visible
     text-overflow: initial


### PR DESCRIPTION
- Add horizontal and vertical scrollbars to the RemoteFileTree component #256
- Disable files without bcup extension
- Show pointer cursor on bcup files
- Toggle directories on Click & Double click instead of expanding on Double Click
- Fix error on validation message for local vault's name
- Fix error on validation message for WebDAV's name
- Submit forms when pressing enter
- Position LoadingModal on top of icons and notification messages
- Change `throw new Error()` to `log.error()`