### PR TITLE
Add max-height to vaults menu

### DIFF
--- a/source/popup/components/HeaderBar.js
+++ b/source/popup/components/HeaderBar.js
@@ -13,6 +13,11 @@ const Container = styled.div`
     padding: 0.5rem 0.5rem 0.25rem;
 `;
 
+const ArchiveMenu = styled(Menu)`
+    max-height: 250px;
+    overflow: auto;
+`;
+
 class HeaderBar extends PureComponent {
     static propTypes = {
         archives: ArchivesShape,
@@ -46,7 +51,7 @@ class HeaderBar extends PureComponent {
     render() {
         const { archives, location, darkMode } = this.props;
         const archiveMenu = (
-            <Menu>
+            <ArchiveMenu>
                 <If condition={archives.length > 0}>
                     <MenuDivider title="Vaults:" />
                     <For each="vault" of={archives} index="index">
@@ -63,7 +68,7 @@ class HeaderBar extends PureComponent {
                 <MenuItem text="Add Vault" icon="add" onClick={::this.props.onAddVaultClick} />
                 <MenuItem text="Lock All Vaults" icon="lock" onClick={::this.props.onLockAllClick} />
                 <MenuItem icon="numbered-list" text="Manage Vaults" onClick={this.props.onVaultsClick} />
-            </Menu>
+            </ArchiveMenu>
         );
         const optionsMenu = (
             <Menu>


### PR DESCRIPTION
When the extension has more than 7 registered vaults, it starts growing past the extension's window's height.

This PR adds a `max-height` of 250px and a scroll if needed.

**Before:**
![image](https://user-images.githubusercontent.com/127994/61192481-36f8b280-a67a-11e9-9c1b-dd450fc760ec.png)

**After:**
![image](https://user-images.githubusercontent.com/127994/61192462-2b0cf080-a67a-11e9-8353-cfa307327ab8.png)
