### PR TITLE
Adding alias for imports

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -141,6 +141,13 @@ const backgroundConfig = Object.assign({}, getBaseConfig(), {
         path: DIST
     },
 
+    resolve: {
+        alias: {
+            src: path.resolve(__dirname, "source")
+        },
+        extensions: [".js", ".jsx", ".json"]
+    },
+
     plugins: [
         ...getBasePlugins(),
         new CopyWebpackPlugin([


### PR DESCRIPTION
By adding alias for imports code can start importing as

```
import { performAuthentication } from "src/shared/library/googleDrive";
```

instead of

```
import { performAuthentication } from "../../shared/library/googleDrive.js";
```
