### PR TITLE
Google drive permissions option

### DIFF
--- a/source/background/library/googleDrive.js
+++ b/source/background/library/googleDrive.js
@@ -10,18 +10,20 @@ import { closeTabs, createNewTab } from "../../shared/library/extension.js";
 import { getArchiveManager } from "./buttercup.js";
 import secrets from "../../shared/google-client.json";
 
-const GOOGLE_DRIVE_SCOPES = [
-    "email",
-    "profile",
+const GOOGLE_DRIVE_BASE_SCOPES = ["email", "profile"];
+const GOOGLE_DRIVE_SCOPES_STANDARD = [
+    ...GOOGLE_DRIVE_BASE_SCOPES,
     "https://www.googleapis.com/auth/drive.file" // Per-file access
 ];
+const GOOGLE_DRIVE_SCOPES_PERMISSIVE = [...GOOGLE_DRIVE_BASE_SCOPES, "https://www.googleapis.com/auth/drive"];
 const OAUTH_REDIRECT_URL = "https://buttercup.pw?googleauth";
 
-export async function authenticateWithoutToken(authID = uuid()) {
+export async function authenticateWithoutToken(authID = uuid(), useOpenPermissions = false) {
+    const scopes = useOpenPermissions ? GOOGLE_DRIVE_SCOPES_PERMISSIVE : GOOGLE_DRIVE_SCOPES_STANDARD;
     const oauth2Client = getOAuthClient();
     const url = oauth2Client.generateAuthUrl({
         access_type: "offline",
-        scope: [...GOOGLE_DRIVE_SCOPES],
+        scope: [...scopes],
         prompt: "consent select_account"
     });
     const cleanup = async () => {

--- a/source/background/library/messaging.js
+++ b/source/background/library/messaging.js
@@ -90,8 +90,8 @@ function handleMessage(request, sender, sendResponse) {
             return true;
         }
         case "authenticate-google-drive": {
-            const { authID } = request;
-            authenticateGoogleDrive(authID);
+            const { useOpenPermissions = false } = request;
+            authenticateGoogleDrive(undefined, useOpenPermissions);
             return false;
         }
         case "change-vault-password": {

--- a/source/setup/components/AddArchivePage.js
+++ b/source/setup/components/AddArchivePage.js
@@ -93,7 +93,10 @@ class AddArchivePage extends PureComponent {
 
     handleGoogleDriveAuth(event) {
         event.preventDefault();
-        this.props.onAuthenticateGoogleDrive(this.state.googleDriveAuthenticationID);
+        this.props.onAuthenticateGoogleDrive(
+            this.state.googleDriveAuthenticationID,
+            this.state.googleDriveOpenPermissions
+        );
     }
 
     handleChooseDropboxBasedFile(event) {

--- a/source/setup/components/AddArchivePage.js
+++ b/source/setup/components/AddArchivePage.js
@@ -1,7 +1,7 @@
 import React, { PureComponent, Fragment } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import { Card, Button, H3, H4, FormGroup, InputGroup, Intent } from "@blueprintjs/core";
+import { Button, Callout, Card, Checkbox, H3, H4, FormGroup, InputGroup, Intent } from "@blueprintjs/core";
 import uuid from "uuid/v4";
 import { Input as ButtercupInput, Button as ButtercupButton } from "@buttercup/ui";
 import switchcase from "switchcase";
@@ -10,6 +10,9 @@ import ArchiveTypeChooser from "../containers/ArchiveTypeChooser.js";
 import { ARCHIVE_TYPES } from "./ArchiveTypeChooser.js";
 import RemoteExplorer from "../containers/RemoteExplorer.js";
 
+const CalloutWithSpacing = styled(Callout)`
+    margin-bottom: 10px;
+`;
 const Spacer = styled.div`
     width: 100%;
     height: 2rem;
@@ -59,6 +62,7 @@ class AddArchivePage extends PureComponent {
         archiveName: "",
         dropboxAuthenticationID: "",
         googleDriveAuthenticationID: "",
+        googleDriveOpenPermissions: false,
         localCode: "",
         masterPassword: "",
         myButtercupAuthenticationID: "",
@@ -176,7 +180,7 @@ class AddArchivePage extends PureComponent {
             .case("localfile", "localfile");
         const fetchType = fetchTypeSwitch(this.props.selectedArchiveType);
         return (
-            <LayoutMain title="Add Archive">
+            <LayoutMain title="Add Vault">
                 <H4>Choose Vault Type</H4>
                 <ArchiveTypeChooser disabled={hasAuthenticated} />
                 <Spacer />
@@ -342,6 +346,24 @@ class AddArchivePage extends PureComponent {
                                 To start, please grant Buttercup access to your Google Drive account. This access will
                                 be only used to store and read a Buttercup Vault that you choose or create.
                             </p>
+                            <CalloutWithSpacing intent={Intent.PRIMARY}>
+                                <p>
+                                    Buttercup, by default, will use permissions that only allow connecting to new vaults
+                                    or existing vaults that were created or accessed by Buttercup previously.
+                                </p>
+                                <p>
+                                    If you wish to connect to an existing vault that was{" "}
+                                    <strong>uploaded manually</strong>, you'll need to grant additional permissions to
+                                    connect it.
+                                </p>
+                                <Checkbox
+                                    checked={this.state.googleDriveOpenPermissions}
+                                    label="Grant access to all Google Drive contents"
+                                    onChange={evt =>
+                                        this.setState({ googleDriveOpenPermissions: !!evt.target.checked })
+                                    }
+                                />
+                            </CalloutWithSpacing>
                             <Button
                                 icon="key"
                                 onClick={::this.handleGoogleDriveAuth}

--- a/source/setup/containers/AddArchivePage.js
+++ b/source/setup/containers/AddArchivePage.js
@@ -36,7 +36,10 @@ import {
     addWebDAVArchive
 } from "../library/archives.js";
 import { setBusy, unsetBusy } from "../../shared/actions/app.js";
-import { setAuthID as setGoogleDriveAuthID } from "../../shared/actions/googleDrive.js";
+import {
+    setAuthID as setGoogleDriveAuthID,
+    setAccessToken as setGoogleDriveAccessToken
+} from "../../shared/actions/googleDrive.js";
 import { setAuthID as setDropboxAuthID } from "../../shared/actions/dropbox.js";
 import { getAuthID as getDropboxAuthID, getAuthToken as getDropboxAuthToken } from "../../shared/selectors/dropbox.js";
 import { performAuthentication as performDropboxAuthentication } from "../library/dropbox.js";
@@ -191,6 +194,8 @@ export default connect(
                     );
                 })
                 .then(() => {
+                    dispatch(setGoogleDriveAuthID(null));
+                    dispatch(setGoogleDriveAccessToken(null));
                     dispatch(unsetBusy());
                     notifySuccess("Successfully added vault", `The vault '${archiveName}' was successfully added.`);
                     setTimeout(() => {

--- a/source/setup/containers/AddArchivePage.js
+++ b/source/setup/containers/AddArchivePage.js
@@ -101,9 +101,9 @@ export default connect(
             dispatch(setDropboxAuthID(dropboxAuthID));
             performDropboxAuthentication();
         },
-        onAuthenticateGoogleDrive: googleDriveAuthID => dispatch => {
+        onAuthenticateGoogleDrive: (googleDriveAuthID, useOpenPermissions = false) => dispatch => {
             dispatch(setGoogleDriveAuthID(googleDriveAuthID));
-            authenticateGoogleDrive();
+            authenticateGoogleDrive(useOpenPermissions);
         },
         onAuthenticateMyButtercup: myButtercupAuthID => dispatch => {
             dispatch(setMyButtercupAuthID(myButtercupAuthID));

--- a/source/setup/library/messaging.js
+++ b/source/setup/library/messaging.js
@@ -35,8 +35,8 @@ export function applyArchiveFacade(sourceID, facade) {
     });
 }
 
-export function authenticateGoogleDrive(authID) {
-    chrome.runtime.sendMessage({ type: "authenticate-google-drive", authID });
+export function authenticateGoogleDrive(useOpenPermissions = false) {
+    chrome.runtime.sendMessage({ type: "authenticate-google-drive", useOpenPermissions });
 }
 
 export function changeSourcePassword(sourceID, oldPassword, newPassword) {


### PR DESCRIPTION
Adds an option to configure how open the scopes should be for Buttercup's access to Google Drive. **Defaults to the less-permissive option**. Fixes #313 _

![image](https://user-images.githubusercontent.com/3869469/72667379-06784380-3a24-11ea-8a3f-4cf7a6a85d2f.png)

_Also fixes #270 - a but with allowing multiple Google accounts._