### PR TITLE
Allow localhost to be added to disabled domains

### DIFF
--- a/source/setup/components/DisabledLoginDomainsPage.js
+++ b/source/setup/components/DisabledLoginDomainsPage.js
@@ -14,7 +14,7 @@ const Table = styled.table`
 `;
 
 function isDomain(str) {
-    return /^[^\/:_]+(\.[^\/:_]+)+$/.test(str);
+    return /^[^\/:_]+(\.[^\/:_]+)+$/.test(str) || str === "localhost";
 }
 
 export default function DisabledLoginDomainsPage() {


### PR DESCRIPTION
This is a small change to allow adding `localhost` to the list of disabled save-details prompts domains.

![image](https://user-images.githubusercontent.com/13941027/83775884-64c65b80-a67f-11ea-829d-cb311cb1a39e.png)
